### PR TITLE
fix: Firebase二重初期化クラッシュを修正しATT対応を追加

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,26 +1,20 @@
 PODS:
   - Flutter (1.0.0)
-  - flutter_native_splash (0.0.1):
-    - Flutter
   - in_app_review (0.2.0):
     - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - in_app_review (from `.symlinks/plugins/in_app_review/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
-  flutter_native_splash:
-    :path: ".symlinks/plugins/flutter_native_splash/ios"
   in_app_review:
     :path: ".symlinks/plugins/in_app_review/ios"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   in_app_review: 318597b3a06c22bb46dc454d56828c85f444f99d
 
 PODFILE CHECKSUM: 4f1c12611da7338d21589c0b2ecd6bd20b109694

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -489,7 +489,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 2NGCBTHK5K;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -497,7 +497,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kanbe.highandlow;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -706,7 +706,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 2NGCBTHK5K;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -714,7 +714,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kanbe.highandlow;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -731,7 +731,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 2NGCBTHK5K;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -739,7 +739,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kanbe.highandlow;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -8,6 +8,10 @@ import Firebase
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // Firebase はアプリ起動時に一度だけ構成する。
+    // didInitializeImplicitFlutterEngine は複数回呼ばれ得るため、
+    // ここに置かないと二重初期化で SIGABRT クラッシュする。
+    FirebaseApp.configure()
     // UIScene ライフサイクル移行に伴い、プラグイン登録は
     // didInitializeImplicitFlutterEngine に移動した。
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
@@ -15,6 +19,5 @@ import Firebase
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
-    FirebaseApp.configure()
   }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -271,5 +271,7 @@
 		<true/>
 		<key>UIStatusBarHidden</key>
 		<true/>
+		<key>NSUserTrackingUsageDescription</key>
+		<string>This identifier will be used to deliver personalized ads to you.</string>
 	</dict>
 </plist>

--- a/lib/Ad/TrackingConsent.dart
+++ b/lib/Ad/TrackingConsent.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:app_tracking_transparency/app_tracking_transparency.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart' as admob;
+
+/// 広告表示前の同意取得（UMP同意フロー + ATT）をまとめて扱う。
+///
+/// AdMob を初期化する前に [request] を一度だけ呼ぶこと。
+/// 呼び出し順は「UMP同意フォーム → ATTダイアログ → AdMob初期化」の順で、
+/// この順序を守らないと ATT の許諾状態が広告リクエストに反映されない。
+class TrackingConsent {
+  /// The internal constructor.
+  TrackingConsent._internal();
+
+  /// Returns the singleton instance of [TrackingConsent].
+  static TrackingConsent get instance => _singletonInstance;
+
+  /// The singleton instance of this [TrackingConsent].
+  static final _singletonInstance = TrackingConsent._internal();
+
+  /// UMP の同意情報を更新し、必要なら同意フォームを表示したうえで、
+  /// iOS では続けて ATT のダイアログを表示する。
+  ///
+  /// AdMob の `MobileAds.instance.initialize()` を呼ぶ前に実行すること。
+  Future<void> request() async {
+    await _requestUmpConsent();
+    await _requestAppTrackingTransparency();
+  }
+
+  /// UMP（User Messaging Platform）の同意情報を更新し、
+  /// 表示が必要な場合は同意フォームを提示する。
+  ///
+  /// EEA 等の対象地域以外では基本的にフォームは表示されない。
+  /// 同意取得に失敗しても広告表示自体は継続できるため、例外は握りつぶす。
+  Future<void> _requestUmpConsent() async {
+    final completer = Completer<void>();
+    admob.ConsentInformation.instance.requestConsentInfoUpdate(
+      admob.ConsentRequestParameters(),
+      () async {
+        try {
+          await admob.ConsentForm.loadAndShowConsentFormIfRequired((_) {});
+        } catch (_) {
+          // 同意フォームの取得・表示に失敗しても続行する。
+        }
+        if (!completer.isCompleted) completer.complete();
+      },
+      (admob.FormError error) {
+        // 同意情報の更新に失敗しても続行する。
+        if (!completer.isCompleted) completer.complete();
+      },
+    );
+    await completer.future;
+  }
+
+  /// iOS で ATT のトラッキング許可ダイアログを表示する。
+  ///
+  /// まだ未確定（notDetermined）の場合のみ OS 標準ダイアログを表示し、
+  /// すでに許可/拒否済みの場合は何もしない。iOS 以外では何もしない。
+  Future<void> _requestAppTrackingTransparency() async {
+    if (!Platform.isIOS) return;
+    final status =
+        await AppTrackingTransparency.trackingAuthorizationStatus;
+    if (status == TrackingStatus.notDetermined) {
+      await AppTrackingTransparency.requestTrackingAuthorization();
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart' as admob;
 import 'package:high_and_low/Ad/InterstitialAd.dart';
+import 'package:high_and_low/Ad/TrackingConsent.dart';
 import 'package:high_and_low/ReviewDialog/ShowDialog.dart';
 import 'package:high_and_low/PlayingCardsPage/View/PlayingCardsView.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -12,6 +13,8 @@ Future<void> main() async {
     DeviceOrientation.landscapeLeft,
     DeviceOrientation.landscapeRight,
   ]);
+  // UMP同意フローとATTの許可取得を、AdMob初期化より前に行う。
+  await TrackingConsent.instance.request();
   await admob.MobileAds.instance.initialize();
   await InterstitialAd.instance.load();
   await recordFirstLaunchIfNeeded();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  app_tracking_transparency:
+    dependency: "direct main"
+    description:
+      name: app_tracking_transparency
+      sha256: "3a52669c0645ffd7efe9a460047616de3e3f2128338f9ec7cdb681628d36238e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   archive:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: 'none'
 
-version: 1.1.0+11
+version: 1.2.0+12
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
@@ -23,6 +23,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   google_mobile_ads: ^9.0.0
+  app_tracking_transparency: ^2.0.7
   flutter_hooks: ^0.20.1
   hooks_riverpod: ^2.4.0
   riverpod_annotation: ^2.1.5


### PR DESCRIPTION
- FirebaseApp.configure()をdidFinishLaunchingWithOptionsに移動 （didInitializeImplicitFlutterEngineは複数回呼ばれ得るため二重初期化でSIGABRTクラッシュしていた）
- app_tracking_transparencyを追加しATT許可ダイアログを表示
- UMP同意フロー→ATT→AdMob初期化の順に実行するTrackingConsentを追加
- NSUserTrackingUsageDescription（英語）をInfo.plistに追加
- バージョンを1.2.0+12に更新